### PR TITLE
fix: time sync issue with Binance API

### DIFF
--- a/monitor/position_monitor.py
+++ b/monitor/position_monitor.py
@@ -4,12 +4,21 @@ from dotenv import load_dotenv
 from binance.client import Client
 from tabulate import tabulate
 import argparse
+import time
+
+
+def sync_binance_time(client):
+    server_time = client.get_server_time()["serverTime"]
+    local_time = int(time.time() * 1000)
+    client.TIME_OFFSET = server_time - local_time
+
 
 # Load .env variables
 load_dotenv()
 API_KEY = os.getenv("BINANCE_API_KEY")
 API_SECRET = os.getenv("BINANCE_API_SECRET")
 client = Client(API_KEY, API_SECRET)
+sync_binance_time(client)
 
 # Load coin config
 with open("config/coins.json") as f:

--- a/monitor/price_monitor.py
+++ b/monitor/price_monitor.py
@@ -17,7 +17,15 @@ load_dotenv()
 API_KEY = os.getenv("BINANCE_API_KEY")
 API_SECRET = os.getenv("BINANCE_API_SECRET")
 
+
+def sync_binance_time(client):
+    server_time = client.get_server_time()["serverTime"]
+    local_time = int(time.time() * 1000)
+    client.TIME_OFFSET = server_time - local_time
+
+
 client = Client(API_KEY, API_SECRET)
+sync_binance_time(client)
 
 # Load symbols from config
 with open("config/coins.json") as f:


### PR DESCRIPTION
Somtimes request to Binance API will return this error:

```
Timestamp for this request is outside of the recvWindow.
```

This pr fixes it.