### PR TITLE
feat: integrate Docker and Makefile targets for containerized workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.venv/
+.git/
+tests/
+.dockerignore
+Dockerfile
+README.md 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,18 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: docker build -t buibui-bot . 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Poetry
+RUN pip install poetry
+
+# Copy only dependency files first for better build caching
+COPY pyproject.toml poetry.lock* /app/
+
+# Install dependencies (no dev dependencies for production)
+RUN poetry install --no-root
+
+# Copy the rest of the code
+COPY . /app
+
+# Set environment variables (optional)
+ENV PYTHONUNBUFFERED=1
+
+# No default CMD; user must specify the command when running the container 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 MARKDOWN_FILES = $(shell find . -name "*.md")
 PYTHON_FILES = $(shell find . -name "*.py")
+DOCKER_IMAGE = buibui-bot
 
-.PHONY: lint lint-md lint-py format format-py
+.PHONY: lint lint-md lint-py format format-py docker-build docker-run-price docker-run-position
 
 lint: lint-md lint-py
 
@@ -20,3 +21,15 @@ format: format-py
 format-py:
 	@echo "🎨 Formatting Python code with black..."
 	black $(PYTHON_FILES)
+
+docker-build:
+	@echo "🐳 Building Docker image..."
+	docker build -t $(DOCKER_IMAGE) .
+
+docker-run-price:
+	@echo "🐳 Running price_monitor in Docker..."
+	docker run --env-file .env $(DOCKER_IMAGE) poetry run python monitor/price_monitor.py
+
+docker-run-position:
+	@echo "🐳 Running position_monitor in Docker..."
+	docker run --env-file .env $(DOCKER_IMAGE) poetry run python monitor/position_monitor.py

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ Edit `config/coins.json` to define each symbol's leverage and stop-loss percent.
 }
 ```
 
+## 🐳 Docker & Makefile Usage
+
+You can use Docker to run your bot in a consistent environment, and the Makefile provides easy commands for building and running your container.
+
+### Build the Docker image
+
+```bash
+make docker-build
+```
+
+### Run the price monitor in Docker
+
+```bash
+make docker-run-price
+```
+
+### Run the position monitor in Docker
+
+```bash
+make docker-run-position
+```
+
+All commands use your `.env` file for secrets and config.
+
 ## 🛠️ Usage
 
 ### 🧾 Open Multiple Trades (manually)


### PR DESCRIPTION
## What’s Changed

- Added a Dockerfile to enable running the bot in a consistent, containerized environment using Poetry for dependency management.
- Added a .dockerignore file to exclude unnecessary files from Docker images, improving build speed and image cleanliness.
- Enhanced the Makefile with convenient targets:
  - `make docker-build` — Build the Docker image
  - `make docker-run-price` — Run the price monitor in Docker
  - `make docker-run-position` — Run the position monitor in Docker
- Updated the README with clear instructions for building and running the bot using Docker and the Makefile.

## Why

- Simplifies setup and deployment on any machine or VPS (e.g., Oracle Cloud)
- Ensures consistency across development, CI, and production environments
- Makes onboarding and running the bot easier for all contributors

## How to Use

- Build the Docker image: `make docker-build`
- Run the price monitor: `make docker-run-price`
- Run the position monitor: `make docker-run-position`
- All commands use your `.env` file for secrets and config

---

Ready for review!