### PR TITLE
refactor: make cli commands more user-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ docker-build:
 
 docker-run-price:
 	@echo "🐳 Running price_monitor in Docker..."
-	docker run --env-file .env $(DOCKER_IMAGE) poetry run python monitor/price_monitor.py
+	docker run --env-file .env $(DOCKER_IMAGE) poetry run python buibui.py monitor price
 
 docker-run-position:
 	@echo "🐳 Running position_monitor in Docker..."
-	docker run --env-file .env $(DOCKER_IMAGE) poetry run python monitor/position_monitor.py
+	docker run --env-file .env $(DOCKER_IMAGE) poetry run python buibui.py monitor position

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ You'll be prompted to enter:
 ### 📈 Monitor Prices
 
 ```bash
-poetry run python monitor/price_monitor.py
+poetry run python buibui.py monitor price
 ```
 
 This will run once and exit by default.
 To run in live refresh mode:
 
 ```bash
-poetry run python monitor/price_monitor.py --live
+poetry run python buibui.py monitor price --live
 ```
 
 It shows:
@@ -192,7 +192,7 @@ Example Output:
 ### 📊 Monitor Positions & PnL
 
 ```bash
-poetry run python monitor/position_monitor.py [--sort key[:asc|desc]]
+poetry run python buibui.py monitor position [--sort key[:asc|desc]]
 ```
 
 Shows:
@@ -229,10 +229,9 @@ Sorting Options:
 - You can now control how the table is sorted using the `--sort` flag.
 
 ```bash
-poetry run python monitor/position_monitor.py --sort pnl_pct:desc   # Sort by highest PnL%
-poetry run python monitor/position_monitor.py --sort sl_usd:asc     # Sort by lowest SL risk
-poetry run python monitor/position_monitor.py --sort default         # Sort by coins.json order (default)
-
+poetry run python buibui.py monitor position --sort pnl_pct:desc   # Sort by highest PnL%
+poetry run python buibui.py monitor position --sort sl_usd:asc     # Sort by lowest SL risk
+poetry run python buibui.py monitor position --sort default        # Sort by coins.json order (default)
 ```
 
 Supported sort keys:

--- a/buibui.py
+++ b/buibui.py
@@ -1,0 +1,46 @@
+import argparse
+from monitor import price_monitor, position_monitor
+
+
+def run_price_monitor(args):
+    price_monitor.main(live=args.live, telegram=args.telegram)
+
+
+def run_position_monitor(args):
+    position_monitor.main(sort=args.sort, telegram=args.telegram)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Buibui Moon Trader CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Top-level 'monitor' command
+    monitor_parser = subparsers.add_parser("monitor", help="Monitoring tools")
+    monitor_subparsers = monitor_parser.add_subparsers(
+        dest="monitor_command", required=True
+    )
+
+    # 'price' subcommand
+    price_parser = monitor_subparsers.add_parser("price", help="Run price monitor")
+    price_parser.add_argument("--live", action="store_true", help="Live refresh mode")
+    price_parser.add_argument(
+        "--telegram", action="store_true", help="Send output to Telegram"
+    )
+    price_parser.set_defaults(func=run_price_monitor)
+
+    # 'position' subcommand
+    position_parser = monitor_subparsers.add_parser(
+        "position", help="Run position monitor"
+    )
+    position_parser.add_argument("--sort", default="default", help="Sort order")
+    position_parser.add_argument(
+        "--telegram", action="store_true", help="Send output to Telegram"
+    )
+    position_parser.set_defaults(func=run_position_monitor)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Refactor: Root-Level CLI, Makefile, and CI Modernization

### What’s changed:
- All CLI usage for price and position monitoring now uses a root-level entrypoint:
  - `python buibui.py monitor price [--live] [--telegram]`
  - `python buibui.py monitor position [--sort ...] [--telegram]`
- Makefile Docker targets updated to use the new CLI structure.
- CI workflow (`docker-build.yaml`) now runs both monitors in Docker using the new CLI.
- All example outputs in the `README` are preserved.
- Documentation updated to explain the new CLI structure and usage.

### Why:
- Improves discoverability, modularity, and future scalability of the CLI.
- Ensures consistency across local, Docker, and CI usage.
- Makes it easier for new users and contributors to understand and use the bot.

### How to test:
- Run the CLI locally or in Docker using the new commands (see `README`).
- CI will automatically build the Docker image and run both monitors as a check.