### PR TITLE
feat: add config file validation

### DIFF
--- a/monitor/position_monitor.py
+++ b/monitor/position_monitor.py
@@ -8,6 +8,7 @@ import time
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import sys
+from utils.config_validation import validate_coins_config
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from utils.telegram import send_telegram_message
@@ -31,8 +32,10 @@ sync_binance_time(client)
 
 # Load coin config
 with open("config/coins.json") as f:
-    COINS_CONFIG = json.load(f)
-    COIN_ORDER = list(COINS_CONFIG.keys())
+    coins_config = json.load(f)
+validate_coins_config(coins_config)
+COINS_CONFIG = coins_config
+COIN_ORDER = list(coins_config.keys())
 
 
 def colorize(value, threshold=0):

--- a/monitor/price_monitor.py
+++ b/monitor/price_monitor.py
@@ -13,6 +13,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from utils.config_validation import validate_coins_config
 from utils.telegram import send_telegram_message
 
 # Init colorama
@@ -37,7 +38,9 @@ sync_binance_time(client)
 
 # Load symbols from config
 with open("config/coins.json") as f:
-    COINS = list(json.load(f).keys())
+    coins_config = json.load(f)
+validate_coins_config(coins_config)
+COINS = list(coins_config.keys())
 
 
 # Format % change with color

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -1,0 +1,28 @@
+def validate_coins_config(config_dict):
+    """
+    Validate the coins.json config dict.
+    Raises ValueError if invalid.
+    """
+    if not isinstance(config_dict, dict):
+        raise ValueError("Config must be a dict of symbol: {leverage, sl_percent}")
+    for symbol, params in config_dict.items():
+        if not isinstance(symbol, str):
+            raise ValueError(f"Symbol key '{symbol}' is not a string.")
+        if not isinstance(params, dict):
+            raise ValueError(f"Value for symbol '{symbol}' must be a dict.")
+        if "leverage" not in params:
+            raise ValueError(f"Symbol '{symbol}' missing 'leverage'.")
+        if "sl_percent" not in params:
+            raise ValueError(f"Symbol '{symbol}' missing 'sl_percent'.")
+        lev = params["leverage"]
+        sl = params["sl_percent"]
+        if not (isinstance(lev, int) or isinstance(lev, float)):
+            raise ValueError(f"Symbol '{symbol}' leverage must be a number.")
+        if not (1 <= lev <= 150):
+            raise ValueError(f"Symbol '{symbol}' leverage {lev} out of range (1-150).")
+        if not (isinstance(sl, int) or isinstance(sl, float)):
+            raise ValueError(f"Symbol '{symbol}' sl_percent must be a number.")
+        if not (0.1 <= sl <= 100):
+            raise ValueError(
+                f"Symbol '{symbol}' sl_percent {sl} out of range (0.1-100)."
+            )


### PR DESCRIPTION
## Summary

This PR standardizes the way `config/coins.json` is loaded and validated in both `monitor/position_monitor.py` and `monitor/price_monitor.py`.

### Key Changes

- Both scripts now:
  - Read `coins.json` once at startup
  - Validate the config using the shared `validate_coins_config` utility
  - Extract relevant variables (`COINS`, `COINS_CONFIG`, `COIN_ORDER`) from the validated config
- Removes redundant file reads and ensures consistent config validation across monitors
- Improves code clarity and maintainability

### Why?

- Prevents subtle bugs from inconsistent config handling
- Makes future refactoring and testing easier

---

Closes #<issue-number-if-applicable>